### PR TITLE
Inter tweet movement

### DIFF
--- a/client/src/AppParameters.tsx
+++ b/client/src/AppParameters.tsx
@@ -1,6 +1,6 @@
 import { RawTweet } from "src/commons/models/rawTweet";
 
-export const DEFAULT_TWEET_UNWRAP_DEPTH = 3;
+export const DEFAULT_TWEET_UNWRAP_DEPTH = 0;
 
 export const DEFAULT_TWEET_DIMENSIONS = { width: 500, height: 160 };
 
@@ -37,7 +37,7 @@ First, she tried to look down and make out what she was coming to,
 but it was too dark to see anything; then she looked at the sides of the well, 
 and noticed that they were filled with cupboards and book-shelves; here and there she saw maps and pictures hung upon pegs. 
 She took down a jar from one of the shelves as she passed.`;
-export function genTestTweet() {
+export function genTestTweets() {
   function* genId() {
     let id = 0;
 
@@ -57,6 +57,8 @@ export function genTestTweet() {
   }
 
   let id = genId();
+  let tweets = [];
+  for(let i = 0; i<12; i++){
   let root = new RawTweet(
     getId(id),
     "John",
@@ -86,6 +88,35 @@ export function genTestTweet() {
   );
   root.debugAddReply(rep1);
   root.debugAddReply(rep2);
-
-  return root;
+  let rep3 = new RawTweet(
+    getId(id),
+    "Henry",
+    "henr24",
+    new Date(Date.now()),
+    "Tweeto..what?",
+    { retweet_count: 0, reply_count: 0, like_count: 1, quote_count: 0 },
+    root
+  );  let rep4 = new RawTweet(
+    getId(id),
+    "Henry",
+    "henr24",
+    new Date(Date.now()),
+    "Tweeto..what?",
+    { retweet_count: 0, reply_count: 0, like_count: 1, quote_count: 0 },
+    root
+  );  let rep5 = new RawTweet(
+    getId(id),
+    "Henry",
+    "henr24",
+    new Date(Date.now()),
+    "Tweeto..what?",
+    { retweet_count: 0, reply_count: 0, like_count: 1, quote_count: 0 },
+    root
+  );
+  rep2.debugAddReply(rep3);
+  rep3.debugAddReply(rep4);
+  rep4.debugAddReply(rep5);
+  tweets.push(root)
+  }
+  return tweets;
 }

--- a/client/src/commons/services/twitterService.tsx
+++ b/client/src/commons/services/twitterService.tsx
@@ -2,7 +2,7 @@ import Tweet from "src/commons/models/tweet";
 import getUserTimeline from "src/apiRequests/getUserTimeline";
 import RawUserTimeline from "../models/rawUserTimeline";
 import { RawTweet } from "../models/rawTweet";
-import { genTestTweet } from "src/AppParameters";
+import { genTestTweets } from "src/AppParameters";
 
 class TwitterService{
 
@@ -14,7 +14,9 @@ class TwitterService{
         let tl_handle = await getUserTimeline("813286").catch(err => {
             console.error(`${err}. Loading example data`)
             let tl = new RawUserTimeline("1");
-            tl.addTweet(genTestTweet());
+            for(const tweet of genTestTweets()){
+                tl.addTweet(tweet);
+            }
             setTimeout(()=>{},500);
             return tl;
         }

--- a/client/src/containers/tweetNode/styles.ts
+++ b/client/src/containers/tweetNode/styles.ts
@@ -4,7 +4,8 @@ interface TweetDivProps{
     backgroundColor: string;
     borderColor: string;
     pos: {x: number, y: number};
-    dimensions: {width: number, height: number}
+    dimensions: {width: number, height: number};
+    selected: boolean;
 }
 
 export const TweetDiv = styled.div<TweetDivProps>`
@@ -19,6 +20,7 @@ export const TweetDiv = styled.div<TweetDivProps>`
   left: ${props => props.pos.x}px;
   top: ${props => props.pos.y}px;
   overflow: hidden;
+  ${props => props.selected?"border: 1px solid red":""};
 
   &:hover {
     overflow: visible;

--- a/client/src/containers/tweetNode/tweetNode.tsx
+++ b/client/src/containers/tweetNode/tweetNode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DisplayTweet from "../../commons/models/displayTweet";
 import { TweetDiv, HeaderDiv } from "./styles";
 import { genAnalytics } from "./services/analyticsGen";
@@ -14,8 +14,16 @@ function TweetNode(props:TweetNodeProps) {
 
   let top_words = genAnalytics(props.data.text);
 
+  let [selected, setSelected] = useState(props.data.selected);
+  useEffect(()=>{
+    props.data.setSelectCallback(setSelected);
+  },[])
+
   return(
-    <TweetDiv onClick={props.onClick} backgroundColor={props.backgroundColor!} borderColor={props.borderColor!} pos={props.data.position} dimensions={props.data.dimension}>
+    <TweetDiv onClick={props.onClick} backgroundColor={props.backgroundColor!} 
+    borderColor={props.borderColor!} 
+    pos={props.data.position} dimensions={props.data.dimension}
+    selected={selected}>
     {/*onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)} style={{ overflow: hover ? "visible" : "hidden", height: hover ? "auto" : "" }}*/}
       {/* If retweet */}
       {props.data.is_retweet ? <p style={{ color: props.nameColor }}>@{props.data.is_retweet} retweeted</p> : null}

--- a/client/src/containers/tweetTree/tweetTree.tsx
+++ b/client/src/containers/tweetTree/tweetTree.tsx
@@ -6,23 +6,7 @@ function TweetTree(props: TweetTreeProps) {
 
 
   async function handleTweetClick(tweet: DisplayTweet){
-    //assumed that all children are switched to the same state
-    let offset = 0;
-    let new_offset = 0;
-
-    let displayChildren = await tweet.displayChildren
-    for(const child of displayChildren){
-      offset = child.position.x+child.subtreeSpan.endX;
-      await child.setHidden(!child.isHidden);
-      new_offset = tweet.position.x+tweet.dimension.width/2;
-    }
-
-    let offsetDiff = offset-new_offset;
-    //if unhiding
-    if(displayChildren.length>0 && !displayChildren[0].isHidden){
-      offsetDiff = -offsetDiff/2;
-    }
-    props.displayUpdateHandler(offsetDiff);
+    props.clickNotifier(tweet);
   }
 
   return <TweetTreeDiv>
@@ -32,7 +16,7 @@ function TweetTree(props: TweetTreeProps) {
 
 export interface TweetTreeProps{
   tweets: DisplayTweet[],
-  displayUpdateHandler: (offsetChange?: number) => any;
+  clickNotifier: (dp: DisplayTweet  ) => any;
 }
 
 export default TweetTree;

--- a/client/src/containers/twitterTimeline/styles.ts
+++ b/client/src/containers/twitterTimeline/styles.ts
@@ -17,15 +17,3 @@ left:0;
 width:100%;
 height:100%;
 `;
-
-
-const Arrow = styled.span<{hidden: boolean}>`
-width: 20px; 
-height: 20px; 
-background: red; 
-position: absolute;
-top: 50%;
-${props=>props.hidden?"display:hidden;":""}`;
-
-export const RightArrow = styled(Arrow)`right: 10px`;
-export const LeftArrow = styled(Arrow)`left: 10px`;

--- a/client/src/containers/twitterTimeline/styles.ts
+++ b/client/src/containers/twitterTimeline/styles.ts
@@ -1,13 +1,13 @@
 import React from "react";
 import styled, { keyframes } from "styled-components";
 
-export const Container = styled.div<{offset: number}>`
+export const Container = styled.div<{offsets: {x:number, y:number}}>`
 position: relative;
 width: 100%;
 height: 100%;
 overflow: hidden;
-> div {transform: translateX(${props => props.offset}px);}
-path {transform: translateX(${props => props.offset}px);}
+> div {transform: translate(${props => props.offsets.x}px,${props=>props.offsets.y}px);}
+path {transform: translate(${props => props.offsets.x}px,${props=>props.offsets.y}px);}
 `;
 
 export const SVGContainer = styled.svg`

--- a/client/src/containers/twitterTimeline/twitterTimeline.tsx
+++ b/client/src/containers/twitterTimeline/twitterTimeline.tsx
@@ -176,7 +176,6 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
 
       let new_span = tweet.subtreeSpan.endX-tweet.subtreeSpan.startX;
       boundShiftOffsets({x:(new_span-initial_span)/2, y:0})
-      console.log("ko")
     }
 
 
@@ -222,7 +221,6 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
     //assume getTimeline is "free" and can be called multiple times
     return(
           <Container onKeyDown={handleKeyPress} tabIndex={0} ref={containerRef} offsets={offsets}>
-            <span>{offsets.x}:{offsets.y}</span>
             <SVGContainer>
               {renderedTweets.flat().map(dTweet => {
                 if(dTweet.displayParent!=null){

--- a/client/src/containers/twitterTimeline/twitterTimeline.tsx
+++ b/client/src/containers/twitterTimeline/twitterTimeline.tsx
@@ -4,7 +4,7 @@ import TwitterService from "../../commons/services/twitterService";
 import TweetArc from "../../components/tweetArc/tweetArc";
 import TweetTree from "../tweetTree/tweetTree";
 import {regenTrees, genTrees} from "./services/tweetTreeGenerator";
-import {Container, LeftArrow, RightArrow, SVGContainer} from "./styles";
+import {Container, SVGContainer} from "./styles";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import {RawTweet} from "src/commons/models/rawTweet";
 import DisplayTweet from "src/commons/models/displayTweet";

--- a/client/src/containers/twitterTimeline/twitterTimeline.tsx
+++ b/client/src/containers/twitterTimeline/twitterTimeline.tsx
@@ -9,6 +9,7 @@ import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 import {RawTweet} from "src/commons/models/rawTweet";
 import DisplayTweet from "src/commons/models/displayTweet";
 import { isElementOfType } from "react-dom/test-utils";
+import { tweetParse } from "src/apiRequests/requestHandling/dataParsing";
 
 
 function TwitterTimeline({someProperty}: {someProperty: string}) {
@@ -28,14 +29,21 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
     //handle scrolling
 
     //offset in pixels
-    const [offset, setOffset] = useState(0);
+    const [offsets, setOffsets] = useState({x:0,y:0});
+    const boundShiftOffsets = (shifts: {x:number, y:number}) => setOffsets(prev=>{
+      return {x: Math.min(prev.x+shifts.x,0), y: Math.min(prev.y+shifts.y,0)}
+    })
+    const boundSetOffsets = (new_offsets: {x:number, y:number}) => setOffsets({
+      x:Math.min(new_offsets.x, 0), 
+      y: Math.min(new_offsets.y,0)
+    });
 
     const containerRef = useRef()  as React.MutableRefObject<HTMLDivElement>
 
 
     //no need to update callback, can just use "prev" from setState method
     const handleScroll = useCallback((event: WheelEvent) => {
-      setOffset(prev => Math.min(prev-event.deltaY, 0));
+      boundShiftOffsets( {x: -event.deltaY, y:0});
     }, [])
 
     useEffect(() => {
@@ -46,79 +54,139 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
 
 
 
-    //handle moving between roots
+    //handle moving between tweets
 
-    function getNextRoot(){
-      if(!containerRef.current){
-        return null;
+    const [selected,setSelected]: [DisplayTweet|null, any] = useState(null);
+
+    function select(dp: DisplayTweet){
+      if(selected){
+        selected.unSelect()
       }
-      let currentCenter = -(offset - containerRef.current.clientWidth/2);
-      let nextGood = false;
+      setSelected(dp);
+      dp.select();
 
-      for(const currentRoot of renderedTweets.map(treeTweets => treeTweets[0].displayRoot)){
-        if(nextGood){
-          return currentRoot;
-        }
-        if(inBetween(currentCenter,currentRoot.subtreeSpan.startX,currentRoot.subtreeSpan.endX)){
-          nextGood = true;
-        }
-      }
-
-      return null;
-    }
-
-    function getPrevRoot(){
-      if(!containerRef.current){
-        return null;
-      }
-      let currentCenter = -(offset - containerRef.current.clientWidth/2);
-      let prev = null;
-      let prevPrev = null;
-      let prevGood = false;
-
-      for(const currentRoot of renderedTweets.map(treeTweets => treeTweets[0].displayRoot)){
-        if(prevGood){
-          return prev;
-        }
-        if(inBetween(currentCenter,currentRoot.subtreeSpan.startX,currentRoot.subtreeSpan.endX)){
-          prevGood = true;
-        }else{
-          prev = currentRoot;
-        }
-
-
-      }
-      //if outside of a tree, just go to the last one
-      return prev;
-
-    }
-
-    function goToNextRoot(){
-      let currentCenter = containerRef.current.clientWidth/2;
-      let target = getNextRoot();
-      if(target && target!==null){
-        setOffset(prev => Math.min(0, currentCenter - target!.position.x - target!.dimension.width/2));
-      }
-    }
-
-    function goToPrevRoot(){
-      let currentCenter = containerRef.current.clientWidth/2;
-      let target = getPrevRoot();
-      if(target && target!==null){
-        setOffset(prev => Math.min(0, currentCenter - target!.position.x - target!.dimension.width/2));
-      }
+      centerTweet(dp);
     }
 
 
-    async function updateDisplay(offsetChange?: number){
+    const centerTweet = (tweet: DisplayTweet) => {
+      boundSetOffsets(
+      {x: -(tweet.position.x+tweet.dimension.width/2-containerRef.current.offsetWidth/2) ,
+       y: -(tweet.position.y+tweet.dimension.height/2-containerRef.current.offsetHeight/2)});
+      };
+
+    async function handleKeyPress(event: React.KeyboardEvent){
+      //if no tweet selected, select one
+      if(!selected){
+        selectFirst();
+        return;
+      }
+
+      const s = selected!;
+
+      switch(event.key){
+        case("ArrowLeft"):
+          const left = await getNextDT(true, selected, null, selected, 0);
+          if(left){
+            select(left);
+          }
+        break;
+        case("ArrowRight"):
+          const right = await getNextDT(false, selected, null, selected, 0);
+          if(right){
+            select(right);
+          }
+        break;
+        case("ArrowUp"):
+          if(s.displayParent){
+            select(selected!.displayParent!)
+          }
+        break;
+        case("ArrowDown"):
+          //if hiding, just show children
+          if(s.isHiding){
+            setHideTweet(s!, false);
+            break;
+          }
+
+          const current_children = s.displayedChildren;
+          const nb_cr_children = current_children.length;
+          if(nb_cr_children>0){
+            const new_select = current_children[Math.floor(nb_cr_children/2)]
+            select(new_select);
+          }
+        break;
+
+        case("SpaceBar"):
+        case(" "):
+          setHideTweet(selected, !selected.isHiding);
+        break;
+      }
+    }
+
+    async function getNextDT(left: boolean, orig: DisplayTweet, prev: DisplayTweet|null, current: DisplayTweet|null, depth: number): Promise<DisplayTweet|null>{
+      //if depth 0 and not the start, ok
+      if(depth===0 && current && current.id!==orig.id){
+        return current;
+      }else{
+        //if current is null, assume we're 1 level above roots => children = roots
+        const children = (current===null?getRoots():(await current.displayedChildren)).slice();
+
+        //if looking for first to left, go through array in reverse
+        if(left){
+          children.reverse();
+        }
+
+        let prev_encountered = false;
+        for(const child of children){
+          if(prev_encountered || prev===null){
+            let ret = getNextDT(left, orig, null, child, depth-1)
+            return ret;
+          }
+          else if(prev && child.id===prev.id){
+            prev_encountered = true;
+            continue;
+          }
+        }
+
+        if(!current){
+          return null;
+        }
+        return getNextDT(left, orig, current, current.displayParent, depth+1);
+      }
+    }
+
+    const getRoots = () => renderedTweets.map((d: DisplayTweet[])=> d[d.length-1].displayRoot);
+
+    /**
+     * Selects the first tweet on display, if any
+     */
+    function selectFirst(){
+      if(renderedTweets.length>0){
+         select(renderedTweets[0][renderedTweets[0].length-1]);
+      }
+    }
+
+
+    async function setHideTweet(tweet: DisplayTweet, hide: boolean){
+      let initial_span = tweet.subtreeSpan.endX-tweet.subtreeSpan.startX;
+
+      tweet.setHiding(hide);
+      updateDisplay()
+
+      let new_span = tweet.subtreeSpan.endX-tweet.subtreeSpan.startX;
+      boundShiftOffsets({x:(new_span-initial_span)/2, y:0})
+      console.log("ko")
+    }
+
+
+
+    async function updateDisplay(){
       //just modifying the IDs
       //TODO: actually make 2 distinct arrays?
       setRenderedTweets(
         await regenTrees(renderedTweets.map(arr => Array.from(arr)))
       )
-      if(offsetChange){
-        setOffset(prev => Math.min(prev+offsetChange,0))
-      }
     }
 
 
@@ -129,7 +197,6 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
       async function getTl(){
         let tweets = await twitter.getTimeline()
         let tree = await genTrees(tweets)
-        //can only use 1 setState here
         setRenderedTweets(tree);
       }
       getTl();
@@ -143,10 +210,19 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
     //would filter to only a few tweets that can actually be displayed
     const [renderedTweets, setRenderedTweets]: [DisplayTweet[][], any] = useState([]);
 
+    //update selected if no selected tweet
+    useEffect(()=>{
+      //should only trigger if tweet was unloaded
+      //(requires selected to be set to null when selected tweet unloaded)
+      if(!selected){
+        selectFirst()
+      }
+    },[renderedTweets]);
 
     //assume getTimeline is "free" and can be called multiple times
     return(
-          <Container ref={containerRef} offset={offset}>
+          <Container onKeyDown={handleKeyPress} tabIndex={0} ref={containerRef} offsets={offsets}>
+            <span>{offsets.x}:{offsets.y}</span>
             <SVGContainer>
               {renderedTweets.flat().map(dTweet => {
                 if(dTweet.displayParent!=null){
@@ -156,9 +232,7 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
               })}
             </SVGContainer>
             {renderedTweets.length===0?<span>loading...</span>:<></>}
-            {renderedTweets.map(tweetList => <TweetTree displayUpdateHandler={updateDisplay} key={tweetList[0]!.displayRoot.id} tweets={tweetList}></TweetTree>)}
-            <LeftArrow onClick={goToPrevRoot} hidden={getPrevRoot()===null}></LeftArrow>
-            <RightArrow onClick={goToNextRoot} hidden={getNextRoot()===null}></RightArrow>
+            {renderedTweets.map(tweetList => <TweetTree clickNotifier={select} key={tweetList[tweetList.length-1]!.displayRoot.id} tweets={tweetList}></TweetTree>)}
           </Container>);
 }
 


### PR DESCRIPTION
Should:

- Have a selected tweet on launch (red border)

- Clicking on a tweet should select it
- Selecting a tweet should put it at the center of the container

Condition: div container should be in focus (user needs to click inside of the container to use these)

- Move to the closest tweet on the same level to the right or left when pressing left/right arrow
- Move to the parent when pressing up arrow
- Unhide children when pressing left arrow, if they are hidden
- Move to the closest children if they are not hidden

- Pressing the space bar should toggle between hiding and unhiding the children of the selected tweet
