### PR TITLE
Hide offset fix

### DIFF
--- a/client/src/AppParameters.tsx
+++ b/client/src/AppParameters.tsx
@@ -86,6 +86,26 @@ export function genTestTweets() {
     { retweet_count: 0, reply_count: 0, like_count: 1, quote_count: 0 },
     root
   );
+  let rep10 = new RawTweet(
+    getId(id),
+    "Henry",
+    "henr24",
+    new Date(Date.now()),
+    "Tweeto..what?",
+    { retweet_count: 0, reply_count: 0, like_count: 1, quote_count: 0 },
+    root
+  );
+    let rep11 = new RawTweet(
+    getId(id),
+    "Henry",
+    "henr24",
+    new Date(Date.now()),
+    "Tweeto..what?",
+    { retweet_count: 0, reply_count: 0, like_count: 1, quote_count: 0 },
+    root
+  );
+  root.debugAddReply(rep10);
+  root.debugAddReply(rep11);
   root.debugAddReply(rep1);
   root.debugAddReply(rep2);
   let rep3 = new RawTweet(

--- a/client/src/containers/twitterTimeline/twitterTimeline.tsx
+++ b/client/src/containers/twitterTimeline/twitterTimeline.tsx
@@ -167,15 +167,15 @@ function TwitterTimeline({someProperty}: {someProperty: string}) {
       }
     }
 
-
+    /**
+     * Hides/shows tweets and computes the new offset for tweets to look still
+     * @param tweet the tweet of which the children will be hidden/shown  
+     * @param hide whether the tweets will be hidden or shown
+     */
     async function setHideTweet(tweet: DisplayTweet, hide: boolean){
-      let initial_span = tweet.subtreeSpan.endX-tweet.subtreeSpan.startX;
-
       tweet.setHiding(hide);
-      updateDisplay()
-
-      let new_span = tweet.subtreeSpan.endX-tweet.subtreeSpan.startX;
-      boundShiftOffsets({x:(new_span-initial_span)/2, y:0})
+      await updateDisplay();
+      centerTweet(tweet);
     }
 
 


### PR DESCRIPTION
Fixes issue where hiding/unhiding tweets would modify the offset in weird ways.

Makes call to updateDisplay() blocking, uses centerTweet() function instead of computing offset.

Note: This means it's assumed only the selected tweet will ever be hidden with the setHideTweet() function.
If there's a need to get rid of this assumption:

```ts
const diff = initial_pos-new_pos;
boundShiftOffsets({x:(diff/2)-tweet.dimension.width/2*(diff>0?-1:1), y:0});
```