### PR TITLE
refresh on new user id, twitter service is global

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,20 +1,14 @@
-import React, { useState } from "react";
-import { Link, Outlet } from "react-router-dom";
+import React, { useEffect, useState } from "react";
 import "./assets/style.css";
 import { BaseContainer, MainContainer, NavContainer, EditorButton } from "./baseStyle";
 // import logo from "./logo.svg";
 
 import TwitterTimeline from "./containers/twitterTimeline/twitterTimeline";
-import TwitterLogger from "./containers/twitterLogger";
 import NavBar from "./containers/NavBar/NavBar";
-import getUserTimeline from "./apiRequests/getUserTimeline";
-import getTweet from "./apiRequests/getTweet";
-import getTweetReplies from "./apiRequests/getTweetReplies";
-import sendTweet from "./apiRequests/sendTweet";
-import sendBigTweet from "./apiRequests/sendBigTweet";
 
 import Editor from "./containers/editor/editor";
 import Tweet from "./commons/models/tweet";
+import TwitterService from "./commons/services/twitterService";
 /**
  * Entry point for the app
  * Initialize app-wide systems (request service)
@@ -27,6 +21,7 @@ function App() {
 
   //assumed read-only state except for TwitterTimeline
 
+  const [twitter, setTwitterQuerrier] = useState(new TwitterService());
   const [selectedTweet, setSelectedTweet]: [null|Tweet, any] = useState(null);
   const [requestDisplayRefresh, setRefreshRequestFn]: [() => void, any] = useState(()=>{return ()=>{}});
   const [timelineId, setTimelineId] = useState("813286");
@@ -54,7 +49,7 @@ function App() {
       <MainContainer>
         <Editor SelectedTweet={selectedTweet}></Editor>
         <EditorButton id={"editor-button"} onClick={showEditor}>⇦ Editor</EditorButton>
-        <TwitterTimeline timelineId={timelineId} SelectTweet={setSelectedTweet} SetRefreshHandle={setRefreshRequestFn}></TwitterTimeline>
+        <TwitterTimeline timelineId={timelineId} twitterService={twitter} SelectTweet={setSelectedTweet} SetRefreshHandle={setRefreshRequestFn}></TwitterTimeline>
       </MainContainer>
     </BaseContainer>
   );

--- a/client/src/AppParameters.tsx
+++ b/client/src/AppParameters.tsx
@@ -4,7 +4,14 @@ export const DEFAULT_TWEET_UNWRAP_DEPTH = 0;
 
 export const DEFAULT_TWEET_DIMENSIONS = { width: 500, height: 160 };
 
-export const DEFAULT_SERVER_URL = "http://127.0.0.1:3000"
+//MOVED to serverRequest.tsx because of import issues with webpack
+//export const  DEFAULT_SERVER_URL = "http://127.0.0.1:3000"
+
+
+
+
+
+
 
 const LONG_TEXT = `Alice was beginning to get very tired of sitting by her sister on the bank, 
 and of having nothing to do: once or twice she had peeped into the book her sister was reading, 

--- a/client/src/apiRequests/requestHandling/serverRequest.ts
+++ b/client/src/apiRequests/requestHandling/serverRequest.ts
@@ -1,11 +1,10 @@
 import axios, { AxiosResponse } from 'axios'
-import { DEFAULT_SERVER_URL } from 'src/AppParameters';
 
 /*
 This module makes the call to the server of the application
 */
 
-const serverURL = DEFAULT_SERVER_URL;
+const serverURL = "http://127.0.0.1:3000";
 
 async function serverRequest(route: string, body: any): Promise<any>{
 

--- a/client/src/containers/twitterTimeline/twitterTimeline.tsx
+++ b/client/src/containers/twitterTimeline/twitterTimeline.tsx
@@ -10,8 +10,7 @@ import DisplayTweet from "src/commons/models/displayTweet";
 
 function TwitterTimeline(props: TimelineProps) {
 
-    const twitter = new TwitterService();
-
+    const twitter = props.twitterService;
 
     //handle scrolling
 
@@ -223,20 +222,20 @@ function TwitterTimeline(props: TimelineProps) {
     useEffect(()=>props.SetRefreshHandle(updateDisplay),[])
 
 
-    //assumes getTimeline returns a different object when timeline is updated
 
+    
+ 
     useEffect(()=>{
-      //apparently the only way to get async useEffect?
-      async function getTl(){
+      async function updateTl(){
         let tweets = await twitter.getTimeline(props.timelineId)
         let tree = await genTrees(tweets)
         setRenderedTweets(tree);
+        console.log(tree);
       }
-      getTl();
+      setRenderedTweets([]);
+      updateTl();
     },
-    [])
-    //NOTE: DO NOT REMOVE THE EMPTY DEPENDENCY ARRAY
-    //reason: this should only run when the page is loaded
+    [props.timelineId])
 
 
     //would filter to only a few tweets that can actually be displayed
@@ -254,6 +253,7 @@ function TwitterTimeline(props: TimelineProps) {
     //assume getTimeline is "free" and can be called multiple times
     return(
           <Container id={"timeline-div"} onKeyDown={handleKeyPress} tabIndex={0} ref={containerRef} offsets={offsets}>
+            <span>{props.timelineId}</span>
             <SVGContainer>
               {renderedTweets.flat().map(dTweet => {
                 if(dTweet.displayParent!=null){
@@ -268,7 +268,8 @@ function TwitterTimeline(props: TimelineProps) {
 }
 
 interface TimelineProps{
-  timelineId: string,
+  twitterService: TwitterService
+  timelineId: string
   SelectTweet: (tweet: Tweet|null) => void
   SetRefreshHandle: (f: ()=>void) => void
 }


### PR DESCRIPTION
Fixes the setTimelineId function call, timeline will now render new tweets when modifying timeline id.

Moves TwitterService to App.tsx for use as a caching service in the future.

Hard codes server address in serverRequest.tsx because of import issues.